### PR TITLE
Feature/29 feature 유저 중복 가입 허용

### DIFF
--- a/apps/rest-api-gateway/src/api/user/dto/update-user-request.dto.st.ts
+++ b/apps/rest-api-gateway/src/api/user/dto/update-user-request.dto.st.ts
@@ -1,5 +1,5 @@
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger'
-import { IsBoolean, IsEmail, IsOptional, IsString, Length, Matches } from 'class-validator'
+import { IsBoolean, IsEmail, IsOptional, IsString, Length, Matches, MaxLength } from 'class-validator'
 
 export class UpdateUserRequestDto {
   id: string
@@ -47,5 +47,6 @@ export class UpdateUserRequestDto {
   @ApiPropertyOptional({ example: 'tester1' })
   @IsOptional()
   @IsString()
+  @MaxLength(16)
   nickName?: string
 }

--- a/apps/rest-api-gateway/src/api/user/user.service.ts
+++ b/apps/rest-api-gateway/src/api/user/user.service.ts
@@ -187,9 +187,9 @@ export class UserService {
 
     existUserEntity.deletedAt = new Date()
 
-    existUserEntity.externalId += 'DELETE_'
-    existUserEntity.nickName += 'DELETE_'
-    existUserEntity.email += 'DELETE_'
+    existUserEntity.externalId += 'DELETED_'
+    existUserEntity.nickName += 'DELETED_'
+    existUserEntity.email += 'DELETED_'
 
     await this.userRepository.save(existUserEntity)
 

--- a/apps/rest-api-gateway/src/api/user/user.service.ts
+++ b/apps/rest-api-gateway/src/api/user/user.service.ts
@@ -183,7 +183,15 @@ export class UserService {
       )
     }
 
-    await this.userRepository.softRemove(existUserEntity)
+    // 회원 탈퇴시, 재회원가입 허용을 위해 Unique 처리된 Nickname, externalId, email Key값을 변경해줘야함
+
+    existUserEntity.deletedAt = new Date()
+
+    existUserEntity.externalId += 'DELETE_'
+    existUserEntity.nickName += 'DELETE_'
+    existUserEntity.email += 'DELETE_'
+
+    await this.userRepository.save(existUserEntity)
 
     return { id: request.id }
   }

--- a/apps/rest-api-gateway/src/entity/user.entity.ts
+++ b/apps/rest-api-gateway/src/entity/user.entity.ts
@@ -21,7 +21,7 @@ export class UserEntity {
   @Column({ type: 'uuid', comment: 'oAuth UID' })
   externalId: string
 
-  @Column({ type: 'varchar', unique: true, length: 16 })
+  @Column({ type: 'varchar', unique: true, length: 32 })
   nickName: string
 
   @Column({ length: 255, default: '' })


### PR DESCRIPTION
# description
- 유저 삭제시 Unique 처리된 데이터에 DELETED_ PostFix 추가
  - target : exteranlId, nickName, email
 - nickName 이 PostFix가 추가될 경우, 사용자에게 입력받은 Length보다 길어짐
  - 사용자한테 유저네임 16글자까지 입력받기 가능
    - nickName 에 대해 request될때 Valildation을 16으로 제한
    - entity의 Length는 32로 변경
    